### PR TITLE
feat: switch to ADK single agent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ slack_bolt>=1.22.0
 fastapi>=0.110.0
 starlette>=0.37
 uvicorn[standard]>=0.29.0
-google-genai>=1.31.0
 adk-python>=1.12.0
 httpx>=0.27.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- replace google-genai calls with an Agent Development Kit single-agent runner
- add helper to build content from Slack events and feed ADK runner
- drop google-genai dependency

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa98380c1c832a8c6a60dfd89214f5