### PR TITLE
Add related repository reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ The script will:
 3. Set the required environment variables on the service.
 
 After deployment, configure the Slack app's event subscription URL to the Cloud Run service URL.
+
+## Related Repository
+
+If you want to build a Slack bot that integrates with Salesforce using the ADK framework, check out [Slack Salesforce ADK Agent](https://github.com/danishi/slack-salesforce-adk-agent)🤝


### PR DESCRIPTION
## Summary
Added a reference to a related repository in the README documentation to help users discover complementary resources for building Slack bots with Salesforce integration.

## Changes
- Added a new "Related Repository" section at the end of the README
- Included a link to the [Slack Salesforce ADK Agent](https://github.com/danishi/slack-salesforce-adk-agent) repository with a brief description of its purpose
- This helps users who want to extend their Slack bot implementation with Salesforce integration capabilities

## Details
The addition provides helpful context for users looking to build more advanced Slack bot solutions that integrate with Salesforce using the ADK framework, improving discoverability of related projects in the ecosystem.

https://claude.ai/code/session_014mXnjqpUD3B8XW2RF9tGAH