### PR TITLE
feat: implement ADK Skills reference with SkillToolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ app/
     comedian.py     # ex: Comedian agent implementation
   tools/
     get_current_datetime.py  # ex: Date/time utility tool
+  skills/
+    greeting-skill/          # ex: Greeting skill (file-based ADK Skill)
+      SKILL.md
+      references/
+        greeting_templates.md
+    datetime-skill/          # ex: Datetime skill (file-based ADK Skill)
+      SKILL.md
+      references/
+        default_timezones.md
 scripts/
   deploy.sh         # Helper script to deploy to Cloud Run
 Dockerfile          # Container definition for Cloud Run

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import os
 import json
+import pathlib
 import re
 import uuid
 from typing import List
@@ -14,6 +15,8 @@ from google.genai import types
 from google.adk.agents import Agent
 from google.adk.events.event import Event
 from google.adk.runners import InMemoryRunner
+from google.adk.skills import load_skill_from_dir
+from google.adk.tools.skill_toolset import SkillToolset
 # from google.adk.tools import google_search
 
 from .agents.comedian import comedian_agent
@@ -144,6 +147,16 @@ async def _populate_session_from_thread(
         await session_service.append_event(session=session, event=event_obj)
 
 
+# Load skills from directory
+_skills_dir = pathlib.Path(__file__).parent / "skills"
+greeting_skill = load_skill_from_dir(_skills_dir / "greeting-skill")
+datetime_skill = load_skill_from_dir(_skills_dir / "datetime-skill")
+
+skill_toolset = SkillToolset(
+    skills=[greeting_skill, datetime_skill],
+    additional_tools=[get_current_datetime],
+)
+
 root_agent = Agent(
     name="slack_bot_agent",
     model=MODEL_NAME,
@@ -168,7 +181,7 @@ You are acting as a Slack Bot. All your responses must be formatted using Slack-
 
 Always structure your response clearly, using these rules so it renders correctly in Slack.""",
     tools=[
-        get_current_datetime,
+        skill_toolset,
     ],
     sub_agents=[
         comedian_agent,

--- a/app/skills/datetime-skill/SKILL.md
+++ b/app/skills/datetime-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: datetime-skill
+description: A skill that provides current date and time information for any timezone using the get_current_datetime tool.
+metadata:
+  adk_additional_tools:
+    - get_current_datetime
+---
+
+Step 1: Identify the timezone the user is asking about. If no timezone is specified, check 'references/default_timezones.md' for common defaults.
+Step 2: Use the `get_current_datetime` tool with the appropriate timezone identifier (e.g., "Asia/Tokyo", "America/New_York").
+Step 3: Format the result clearly for the user, including the timezone name and the current date/time.

--- a/app/skills/datetime-skill/references/default_timezones.md
+++ b/app/skills/datetime-skill/references/default_timezones.md
@@ -1,0 +1,16 @@
+# Default Timezone Reference
+
+## Common Timezone Mappings
+- Japan / Tokyo: Asia/Tokyo
+- US East / New York: America/New_York
+- US West / Los Angeles / San Francisco: America/Los_Angeles
+- US Central / Chicago: America/Chicago
+- UK / London: Europe/London
+- Central Europe / Paris / Berlin: Europe/Paris
+- India / Mumbai: Asia/Kolkata
+- China / Beijing / Shanghai: Asia/Shanghai
+- Australia / Sydney: Australia/Sydney
+- Brazil / São Paulo: America/Sao_Paulo
+
+## Default Behavior
+If the user does not specify a timezone, default to "Asia/Tokyo" as the primary user base is in Japan.

--- a/app/skills/greeting-skill/SKILL.md
+++ b/app/skills/greeting-skill/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: greeting-skill
+description: A friendly greeting skill that welcomes users and provides helpful onboarding information about the Slack bot.
+---
+
+Step 1: Read the 'references/greeting_templates.md' file to understand available greeting styles.
+Step 2: Identify the user's name from the `[Speaker: <name>]` tag in the message.
+Step 3: Return a warm, personalized greeting based on the reference, using the user's name.
+Step 4: Briefly mention key capabilities the bot offers (humor via comedian, current datetime lookup).

--- a/app/skills/greeting-skill/references/greeting_templates.md
+++ b/app/skills/greeting-skill/references/greeting_templates.md
@@ -1,0 +1,15 @@
+# Greeting Templates
+
+## Standard Greeting
+Hello, {name}! I'm your Slack Bot assistant. How can I help you today?
+
+## Capabilities Introduction
+Here's what I can do:
+- Answer questions and have conversations
+- Tell jokes and bring humor (via the comedian skill)
+- Look up the current date and time in any timezone
+
+## Tips
+- Mention me in a thread to continue a conversation
+- Ask me to be funny if you want a laugh
+- Ask me what time it is in any city or timezone


### PR DESCRIPTION
## Summary
- Add file-based ADK Skills (`greeting-skill`, `datetime-skill`) under `app/skills/` following the [ADK Skills specification](https://google.github.io/adk-docs/skills/)
- Integrate skills via `SkillToolset` replacing direct tool registration on the root agent
- Each skill has `SKILL.md` (frontmatter + instructions) and `references/` directory with supporting materials

## Details

### ADK Skills structure
```
app/skills/
├── greeting-skill/
│   ├── SKILL.md
│   └── references/
│       └── greeting_templates.md
└── datetime-skill/
    ├── SKILL.md
    └── references/
        └── default_timezones.md
```

### Key changes in `app/main.py`
- Import `load_skill_from_dir` and `SkillToolset` from `google.adk`
- Load both skills from filesystem using `load_skill_from_dir()`
- Create `SkillToolset` with skills + `get_current_datetime` as `additional_tools`
- Pass `skill_toolset` to the root agent's `tools` instead of the raw function

### Reference
- [ADK Skills Documentation](https://google.github.io/adk-docs/skills/)
- [ADK Skills Agent Sample](https://github.com/google/adk-python/tree/main/contributing/samples/skills_agent)

## Test plan
- [ ] Verify the app starts without import errors
- [ ] Mention the bot in Slack and confirm greeting skill activates on hello/greeting messages
- [ ] Ask the bot for the current time and confirm datetime skill activates with correct timezone handling
- [ ] Confirm comedian sub-agent still works as before

https://claude.ai/code/session_01N83Pfw2mYT8viyitEB8d92