### PR TITLE
Add direct message support by refactoring message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you want to use the [Google Gen AI SDK](https://googleapis.github.io/python-g
 If you want a simpler, lightweight Slack bot without the ADK framework, check out [Nano Banana](https://github.com/danishi/slack-nano-banana-bot-on-google-cloud)🍌
 
 ## Features
-- Responds to `@mention` messages in Slack channels.
+- Responds to `@mention` messages in Slack channels and direct messages (DMs).
 - Supports text, image, PDF, text file, video, and audio inputs from Slack messages. Files are fetched via authenticated URLs and sent to Gemini for multimodal understanding.
 - **Web search** via `web_search_agent` (Google Search) and `url_fetch_agent` (URL content retrieval) using `AgentTool`. Allows the bot to look up live web information and fetch page content on demand.
 - **Image generation** via `generate_image` tool using Gemini image generation models:
@@ -102,8 +102,8 @@ The Agent Development Kit includes a built-in web-based Development UI that you 
    - `users:read`
 3. Install the app to your workspace to obtain `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`.
 4. Enable **Event Subscriptions** and set the Request URL to `https://<your-cloud-run-service-url>/slack/events`.
-5. Subscribe to bot events: `app_mention`.
-6. Invite the bot to channels where you want to use it.
+5. Subscribe to bot events: `app_mention`, `message.im`.
+6. Invite the bot to channels where you want to use it. For DMs, simply open a direct message with the bot.
 
 ## Deploy to Cloud Run
 The repository includes a helper script to build the container and deploy to Cloud Run. Ensure your `.env` contains `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` before running:

--- a/app/main.py
+++ b/app/main.py
@@ -218,12 +218,8 @@ def _build_slack_blocks_from_text(text: str) -> List[dict]:
     ] or [{"type": "section", "text": {"type": "mrkdwn", "text": ""}}]
 
 
-@bolt_app.event("app_mention")
-async def handle_mention(body, say, client, logger, ack):
-    # Ack as soon as possible to avoid Slack retries that can cause duplicated responses
-    await ack()
-
-    event = body["event"]
+async def _handle_message(event, say, client, logger):
+    """Shared handler for both app_mention and DM message events."""
     channel = event["channel"]
     message_ts = event["ts"]
     thread_ts = event.get("thread_ts") or message_ts
@@ -303,6 +299,25 @@ async def handle_mention(body, say, client, logger, ack):
         await client.reactions_add(channel=channel, timestamp=message_ts, name=REACTION_COMPLETED)
     except Exception:
         pass
+
+
+@bolt_app.event("app_mention")
+async def handle_mention(body, say, client, logger, ack):
+    await ack()
+    await _handle_message(body["event"], say, client, logger)
+
+
+@bolt_app.event("message")
+async def handle_direct_message(body, say, client, logger, ack):
+    await ack()
+    event = body["event"]
+    # Only handle DMs (channel_type "im"), skip other message events
+    if event.get("channel_type") != "im":
+        return
+    # Ignore bot's own messages and message subtypes (edits, joins, etc.)
+    if event.get("bot_id") or event.get("subtype"):
+        return
+    await _handle_message(event, say, client, logger)
 
 
 @fastapi_app.post("/slack/events")


### PR DESCRIPTION
## Summary
This PR adds support for handling direct messages (DMs) to the Slack bot by extracting the common message handling logic into a shared function and adding a new message event handler.

## Key Changes
- **Refactored message handling logic**: Extracted the core message processing logic from `handle_mention()` into a new `_handle_message()` helper function to enable code reuse
- **Added direct message support**: Implemented a new `handle_direct_message()` event handler that processes incoming DM events with appropriate filtering:
  - Only processes direct messages (channel_type "im")
  - Ignores bot's own messages and message subtypes (edits, joins, etc.)
- **Simplified mention handler**: The `handle_mention()` function now delegates to the shared `_handle_message()` function after acknowledging the event

## Implementation Details
- Both event handlers follow the same pattern: acknowledge the event immediately to prevent Slack retries, then delegate to `_handle_message()` for processing
- The DM handler includes defensive checks to filter out non-DM messages, bot messages, and message subtypes to avoid unintended processing
- No changes to the core message processing logic itself, ensuring existing mention functionality remains unchanged

https://claude.ai/code/session_01FkbkMoaxVNyJqsgAo2uTwm